### PR TITLE
wallet reconnect and wallet disconnect issue fixed

### DIFF
--- a/libs/shared/hpot-sdk/src/config/wagmi/index.ts
+++ b/libs/shared/hpot-sdk/src/config/wagmi/index.ts
@@ -14,7 +14,7 @@ import { berachainMainnet, networks } from '../chains';
 const pId = '23b1ff4e22147bdf7cab13c0ee4bed90';
 
 // Check if wallet needs to be disconnected
-const shouldSetDisconnectedState = () => {
+const setAllWalletsDisconnectedInStorage = () => {
   if (typeof window === 'undefined') return false;
 
   const wagmiStore = localStorage.getItem('wagmi.store');
@@ -41,7 +41,7 @@ const shouldSetAllWalletsDisconnectedInStorage = () => {
   if (typeof window === 'undefined') return;
   
   // Only set disconnected states if needed
-  if (!shouldSetDisconnectedState()) return;
+  if (!setAllWalletsDisconnectedInStorage()) return;
 
   // Set wagmi states
   localStorage.setItem('wagmi.connected', 'false');


### PR DESCRIPTION
this PR will fix bug #85 
To reproduce : 
1-first install multiple providers connect to them then clear the browser tab data then reload you will gets connected to any provider OKX directly because cookie has no session.
2-open browser connects to wallet force quit the browser cookie gets deleted when you will come back you will again connected to the wallet because we are using cookie for persisted data reading .

Issue & Solution  : 
For wallet  connection  the providers do not allow programmatic revocation of permissions .Permissions are granted once and persist until the user manually removes the connection from the wallet UI.That's where complete disconnect will happen. There is no official EIP or method for a dApp to revoke those permissions on the user's behalf.
<img width="1070" alt="Screenshot 2025-06-12 at 11 48 16 AM" src="https://github.com/user-attachments/assets/eb09c1b6-06f6-47dd-a939-9dee154d4605" />
let's suppose we have installed 3 providers and already gave permission to all of them they know the honeypot website now.
https://github.com/wevm/wagmi/blob/main/packages/core/src/actions/disconnect.ts#L54-L60 that's what the default behaviour of wallet connect is it goes to next provider that we have permission  so it means when we disconnect from OKX-->it goes to OKX other intefrace --->then again clicked it goes to phantom ---> then again clicked it goes to metamask  so the image attached states are the  states are only source of truth that will be used to know if user want's the wallet connected or not . and we are using session cookies when we force quit the browser that cookies cleared out so the more viable option is use local storage that is more presistent storage and while create a new config if our local storage is cleared out somehow we will disconnect all of them in our storage again that's what the source of truth for wallet connection if there is  recentConnectionid there or wagmi.state is present it means we don't have to disconnect as user don't disconnected the thing on last state if he did that these the wagmi.state  is empty then .

Fixed Screen Record : 

https://github.com/user-attachments/assets/eb9c5df8-db0a-43fa-b748-c6b6ce83fb05







