### PR TITLE
quote token value doesn't need to be passed explicitly the defined ca…

### DIFF
--- a/libs/shared/hpot-sdk/src/lib/priceFeed/PriceFeedProviders/PriceFeedProviders.ts
+++ b/libs/shared/hpot-sdk/src/lib/priceFeed/PriceFeedProviders/PriceFeedProviders.ts
@@ -189,7 +189,6 @@ export class DefinedPriceFeed implements PriceFeedProvider {
           from: ${input.from}
           to: ${input.to}
           resolution: "${input.resolution}"
-          quoteToken: token${input.tokenNumber ?? 0}
         ) {
           o
           h


### PR DESCRIPTION
this PR will fix #80  
<img width="1431" alt="Screenshot 2025-06-25 at 12 39 53 AM" src="https://github.com/user-attachments/assets/1b61c0d9-dd5c-4fbd-882b-431197e1ecd2" />
…n automatically add that value for us

if you hit the defiend.fi  it automatically determines quoteToken value depends upon the address passed so don't need to explicity pass it