### PR TITLE
timeout added

### DIFF
--- a/libs/shared/hpot-sdk/src/lib/utils/utils.ts
+++ b/libs/shared/hpot-sdk/src/lib/utils/utils.ts
@@ -189,7 +189,7 @@ export class ContractWrite<T extends (...args: any) => any> {
         confirmations: 2,
         hash,
         pollingInterval: 5000,
-        timeout: undefined,
+        timeout: 1000 * 60 * 15, // 15 minutes timeout for less Gas Price: as like OKX estimates very tiny gas Price 
       });
       console.log('transaction', transaction);
       toast.dismiss(pendingPopup);


### PR DESCRIPTION
I faced long time issue with OKX . Mainly OKX gas estimation is much lower e.g OKX estimates this : 0.000000525 Gwei  and where as meta-mask has this  for lowest price :0.002000001  so transection will surely takes some time as validators don't pick low fee transections quickly  . I increased the timeout now before that it's undefined   . Moreover we can show user for better use-ability if the gas price for transection time is too low it will take  approx time up-to 15 minutes .  

For now we can like move with this solution  increasing timeout  i think , but  if the issue seems much critical later on then like the optimal solution for these cases is like optimistically save metadata with pending in database and a background  cron job on dedicated micro-service service actively  looks for if transaction is succeed or not if it  it succeeds then pending status will be changed if cancelled that data will be removed and vice versa .