### PR TITLE
chore(all-in-one-vault): switch reward token from LBGT to WBERA

### DIFF
--- a/apps/all-in-one-vault/components/Table/table.config.tsx
+++ b/apps/all-in-one-vault/components/Table/table.config.tsx
@@ -134,7 +134,7 @@ export const columns: ColumnDef<ReceiptTableData>[] = [
     cell: ({ row }) => {
       const { totalWeight: totalWeightItems } = useOnChainReceipts();
       const weight = Number(row.getValue('weight'));
-      const { data: lbgtBalanceData } = useReadContract({
+      const { data: rewardBalanceData } = useReadContract({
         address: ESTIMATED_REWARDS,
         abi: erc20Abi,
         functionName: 'balanceOf',
@@ -151,12 +151,12 @@ export const columns: ColumnDef<ReceiptTableData>[] = [
       let estimated: string | number | bigint = '-';
       if (
         weight !== undefined &&
-        lbgtBalanceData !== undefined &&
+        rewardBalanceData !== undefined &&
         totalWeightItems !== undefined &&
         decimals !== undefined
       ) {
         const est =
-          (Number(weight) * formatRewards(Number(lbgtBalanceData), decimals)) /
+          (Number(weight) * formatRewards(Number(rewardBalanceData), decimals)) /
           Number(totalWeightItems);
         estimated = formatSmallScientific(est);
       }

--- a/apps/all-in-one-vault/components/summary/summary.tsx
+++ b/apps/all-in-one-vault/components/summary/summary.tsx
@@ -41,16 +41,16 @@ const SummaryCard = memo(function SummaryCard({
   className = '',
   isLoading = false,
 }: SummaryCardProps) {
-  // Helper function to get LBGT token instance
-  const getLBGTTokenInstance = () => {
+  // Helper function to get the reward token (WBERA) instance
+  const getRewardTokenInstance = () => {
     return Token.getToken({
       address: ESTIMATED_REWARDS,
       chainId: wallet.currentChainId.toString(),
     });
   };
 
-  // Get LBGT token instance
-  const lbgtToken = getLBGTTokenInstance();
+  // Get reward token instance
+  const rewardToken = getRewardTokenInstance();
   const formatValue = useMemo(
     () => (value: string | number | bigint) => {
       if (isLoading) return '...';
@@ -81,8 +81,8 @@ const SummaryCard = memo(function SummaryCard({
     functionName: `decimals`,
   });
 
-  // LBGT Balance
-  const { data: lbgtBalanceData } = useReadContract({
+  // Reward token (WBERA) balance held by the vault
+  const { data: rewardBalanceData } = useReadContract({
     address: ESTIMATED_REWARDS,
     abi: erc20Abi,
     functionName: 'balanceOf',
@@ -137,12 +137,12 @@ const SummaryCard = memo(function SummaryCard({
         label: 'Estimated Rewards',
         value:
           data.receiptWeight !== undefined &&
-          lbgtBalanceData !== undefined &&
+          rewardBalanceData !== undefined &&
           totalWeightItems !== undefined &&
           decimals !== undefined
             ? (() => {
                 const receiptWeight = Number(data.receiptWeight);
-                const poolReward = Number(lbgtBalanceData);
+                const poolReward = Number(rewardBalanceData);
                 const totalWeight = Number(totalWeightItems);
 
                 if (
@@ -167,7 +167,7 @@ const SummaryCard = memo(function SummaryCard({
         key: 'estimatedRewards',
       },
     ],
-    [data, lbgtBalanceData, totalWeightItems, decimals]
+    [data, rewardBalanceData, totalWeightItems, decimals]
   );
 
   return (
@@ -189,10 +189,10 @@ const SummaryCard = memo(function SummaryCard({
               >
                 {!isLoading && (
                   <div className="flex items-center justify-center gap-2">
-                    {item.key === 'estimatedRewards' && lbgtToken && (
+                    {item.key === 'estimatedRewards' && rewardToken && (
                       <div>
                         <TokenLogo
-                          token={lbgtToken}
+                          token={rewardToken}
                           size={20}
                           disableTooltip={false}
                         />

--- a/apps/all-in-one-vault/config/algebra/addresses.ts
+++ b/apps/all-in-one-vault/config/algebra/addresses.ts
@@ -119,6 +119,7 @@ export const REWARD_VAULT: Address =
 export const BURN_TO_VAULT: Address =
   '0x9c52cD80455a9ee50610aC90e846e46E04014f6d';
 
+// WBERA — BGT LSTs (LBGT 0xBaadCC29...) deprecated as incentive tokens with PoL Next
 export const ESTIMATED_REWARDS: Address =
-  '0xBaadCC2962417C01Af99fb2B7C75706B9bd6Babe';
+  '0x6969696969696969696969696969696969696969';
 

--- a/apps/all-in-one-vault/pages/all-in-one-vault/components/stat-card.tsx
+++ b/apps/all-in-one-vault/pages/all-in-one-vault/components/stat-card.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Card, Tooltip } from '@nextui-org/react';
+import { Card } from '@nextui-org/react';
 import { useReadContract } from 'wagmi';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import {
   ALL_IN_ONE_VAULT_PROXY,
   ESTIMATED_REWARDS,
@@ -13,7 +12,7 @@ import { useOnChainReceipts } from '@/hooks/useOnChainReceipts';
 export default function StatCard() {
   const { totalWeight: totalWeightItems } = useOnChainReceipts();
 
-  const { data: lbgtBalanceData } = useReadContract({
+  const { data: rewardBalanceData } = useReadContract({
     address: ESTIMATED_REWARDS,
     abi: erc20Abi,
     functionName: 'balanceOf',
@@ -37,14 +36,14 @@ export default function StatCard() {
           : '0.0',
     },
     {
-      label: 'LBGT Balance',
+      label: 'WBERA Balance',
       value:
-        lbgtBalanceData !== undefined && decimals !== undefined
-          ? formatNumber(Number(lbgtBalanceData) / Math.pow(10, decimals))
+        rewardBalanceData !== undefined && decimals !== undefined
+          ? formatNumber(Number(rewardBalanceData) / Math.pow(10, decimals))
           : '0.0',
     },
     {
-      label: 'LBGT Lifetime',
+      label: 'WBERA Lifetime',
       // TODO: Restore when a reliable data source replaces the stalled ghostlogs subgraph
       value: '-',
     },
@@ -61,32 +60,6 @@ export default function StatCard() {
             <div className="p-4 text-center">
               <div className="text-sm text-gray-600 mb-1 font-theader flex items-center justify-center gap-1">
                 {stat.label}
-                {stat.label === 'LBGT Lifetime' && (
-                  <Tooltip
-                    content={
-                      <div className="text-center max-w-xs">
-                        <div className="text-xs">
-                          Berapaw take a 50% fee from all LBGT mint from this
-                          vault while returning 40% bribeback to this vault to
-                          strengthen the bribe power. The actual fee is 10% of
-                          all BGT or 20% of the delivered BGT. The delivered BGT
-                          is half the emission to this vault.
-                        </div>
-                      </div>
-                    }
-                    placement="top"
-                    closeDelay={100}
-                    classNames={{
-                      base: 'z-50',
-                      content:
-                        'bg-black text-white px-3 py-2 rounded text-xs max-w-xs',
-                    }}
-                  >
-                    <div className="inline-flex">
-                      <AiOutlineQuestionCircle className="text-gray-500 hover:text-gray-700 cursor-help text-base" />
-                    </div>
-                  </Tooltip>
-                )}
               </div>
               <div className="text-2xl font-bold text-gray-800">
                 {stat.value}


### PR DESCRIPTION
## Context

Berachain has shipped PoL Next and is deprecating BGT LSTs as eligible incentive tokens. They flagged our **Stake All-in-One Honeypot Vault** ([hub.berachain.com/earn/0xcf4f3e...de9d](https://hub.berachain.com/earn/0xcf4f3eafe6ee37b33c5047f0e6562f764285de9d)) and will blacklist it unless we migrate off LBGT by **July 29**. WBERA (`0x6969...6969`) is already whitelisted as an incentive token on that reward vault (verified on-chain via `getWhitelistedTokens()`), so we are switching incentives to WBERA.

## Changes (frontend display only)

- `apps/all-in-one-vault/config/algebra/addresses.ts`: `ESTIMATED_REWARDS` now points at WBERA instead of LBGT — all balance/estimated-reward reads and the token logo follow this constant.
- `stat-card.tsx`: "LBGT Balance"/"LBGT Lifetime" → "WBERA Balance"/"WBERA Lifetime"; removed the BeraPaw 50%-fee tooltip (obsolete once we stop minting LBGT).
- `summary.tsx`, `table.config.tsx`: renamed `lbgt*` vars to `reward*` (no behavior change).

ABI files (`lib/abis/*`) intentionally untouched — they mirror the deployed contract.

## Not covered here (follow-ups)

1. **Contract**: `AllInOneVault`/`AllInOneLayer` still mint LBGT via BeraPawForge and split bribes LBGT/WBERA — needs an upgrade to route 100% to WBERA before the UI numbers are meaningful. Until then the vault's WBERA balance shown here only reflects the WBERA leg.
2. **Ops**: swap the LBGT returned by Berachain's Incentive Manager to WBERA and re-fund incentives.
3. `apps/wasabee` mini-staker still exposes "Mint LBGT" (`vaultStakerFactory.mintLbgtDefault`) — separate product, needs its own decision.
4. `libs/shared/hpot-sdk/.../chain.tsx` `raisedTokenData` has an entry labeled `LBGT` whose address is actually the AIO staking token (STK `0xa2b0519F...`) — mislabeled, worth cleaning up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)