### PR TITLE
ci: manual Vercel prod deploy workflow for app-all-in-one-vault

### DIFF
--- a/.github/workflows/all-in-one-vault.deployment.yml
+++ b/.github/workflows/all-in-one-vault.deployment.yml
@@ -1,0 +1,20 @@
+name: Deploy app-all-in-one-vault to Vercel (production)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy_all_in_one_vault:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_PROJECT_ID: prj_Nl9aICmsPZm9dQO92Kn0OQDFhmBF
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Deploy to Vercel (production)
+        run: vercel deploy --prod --yes --token=${{ secrets.WORKFLOW_VERCEL_TOKEN }}


### PR DESCRIPTION
Vercel's git integration has ignored pushes to main since April (no previews, no production builds — PR-branch commits build fine), so the LBGT→WBERA change merged in #210 never reached production. This adds a `workflow_dispatch` job that deploys `app-all-in-one-vault` to production via Vercel CLI using the repo's existing `WORKFLOW_VERCEL_TOKEN` / `VERCEL_TEAM_ID` secrets (same pattern as the retired per-app deploy workflows). Submitted from a fork because the primary account's OAuth token lacks the `workflow` scope for direct pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)